### PR TITLE
CRUDController::exportAction sigtanere updated to provide compatibility with the last version of SonataAdminBundle

### DIFF
--- a/Controller/CRUDControllerExtraExportTrait.php
+++ b/Controller/CRUDControllerExtraExportTrait.php
@@ -12,7 +12,7 @@ trait CRUDControllerExtraExportTrait
      * @param Request $request
      * @return Response
      */
-    public function exportAction(Request $request)
+    public function exportAction(Request $request = null)
     {
         /* @var CRUDController $this */
         try {


### PR DESCRIPTION
This small addition needs to provide signature compatibility with the last version (dev-master c30b488) of SonataAdminBundle's CRUDController::exportAction
