### PR TITLE
Fix requirement bundles version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ With [composer](http://packagist.org), add:
 ```json
 {
     "require": {
-        "knplabs/knp-snappy-bundle": "dev-master",
         "whyte624/sonata-admin-extra-export-bundle": "dev-master"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
   ],
   "require" : {
     "php": ">=5.4.0",
-    "sonata-project/admin-bundle": "~2.4",
-    "knplabs/knp-snappy-bundle": "dev-master"
+    "sonata-project/admin-bundle": "~2.3",
+    "knplabs/knp-snappy-bundle": "~1.3"
   },
   "autoload" : {
     "psr-0" : {


### PR DESCRIPTION
  Problem 1
    - The requested package knplabs/knp-snappy-bundle == 1.3.0.0 could not be found.
  Problem 2
    - Installation request for whyte624/sonata-admin-extra-export-bundle dev-master -> satisfiable by whyte624/sonata-admin-extra-export-bundle[dev-master].
    - whyte624/sonata-admin-extra-export-bundle dev-master requires sonata-project/admin-bundle ~2.4 -> no matching package found.
